### PR TITLE
Enable testing with Sphinx 7.2+ (also on Python 3.12)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
         - "3.9"
         - "3.10"
         - "3.11"
-        # - "3.12-dev"
+        - "3.12"
         sphinx:
         - "4"  # jQuery included
         - "5"  # jQuery deprecated

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,10 +30,13 @@ jobs:
         - "4"  # jQuery included
         - "5"  # jQuery deprecated
         - "6"  # jQuery removed
+        - "7"
         exclude:
-        # Sphinx 6 does not support Python 3.7
+        # Sphinx >= 6 does not support Python 3.7
         - python: "3.7"
           sphinx: "6"
+        - python: "3.7"
+          sphinx: "7"
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ jobs:
         - "3.10"
         - "3.11"
         - "3.12"
+        - "3.13-dev"
         sphinx:
         - "4"  # jQuery included
         - "5"  # jQuery deprecated

--- a/tests/test_jquery_installed.py
+++ b/tests/test_jquery_installed.py
@@ -4,10 +4,14 @@ from pathlib import Path
 
 import pytest
 import sphinx
-from sphinx.testing.path import path
 from sphinx.testing.util import SphinxTestApp
 
 from sphinxcontrib.jquery import _FILES, _ROOT_DIR  # NoQA
+
+if sphinx.version_info >= (7, 2):
+    test_path = Path
+else:
+    from sphinx.testing.path import path as test_path
 
 
 def run_blank_app(srcdir, **kwargs):
@@ -26,9 +30,11 @@ def run_blank_app(srcdir, **kwargs):
 @pytest.fixture(scope="function")
 def blank_app(tmpdir, monkeypatch):
     def inner(**kwargs):
-        return run_blank_app(path(tmpdir), **kwargs)
+        return run_blank_app(test_path(tmpdir), **kwargs)
 
-    monkeypatch.setattr("sphinx.application.abspath", lambda x: x)
+    # Sphinx 7.2.x doesn't have abspath
+    if hasattr(sphinx.application, "abspath"):
+        monkeypatch.setattr("sphinx.application.abspath", lambda x: x)
     yield inner
 
 

--- a/tests/test_jquery_installed.py
+++ b/tests/test_jquery_installed.py
@@ -8,7 +8,7 @@ from sphinx.testing.util import SphinxTestApp
 
 from sphinxcontrib.jquery import _FILES, _ROOT_DIR  # NoQA
 
-if sphinx.version_info >= (7, 2):
+if sphinx.version_info[:2] >= (7, 2):
     test_path = Path
 else:
     from sphinx.testing.path import path as test_path
@@ -28,12 +28,12 @@ def run_blank_app(srcdir, **kwargs):
 
 
 @pytest.fixture(scope="function")
-def blank_app(tmpdir, monkeypatch):
+def blank_app(tmp_path, monkeypatch):
     def inner(**kwargs):
-        return run_blank_app(test_path(tmpdir), **kwargs)
+        return run_blank_app(test_path(tmp_path), **kwargs)
 
-    # Sphinx 7.2.x doesn't have abspath
-    if hasattr(sphinx.application, "abspath"):
+    # Sphinx>=7.2 doesn't have abspath
+    if sphinx.version_info[:2] < (7, 2):
         monkeypatch.setattr("sphinx.application.abspath", lambda x: x)
     yield inner
 

--- a/tests/test_jquery_installed.py
+++ b/tests/test_jquery_installed.py
@@ -38,12 +38,14 @@ def test_jquery_installed_sphinx_ge_60_use_sri(blank_app):
     out_dir = blank_app(confoverrides={"extensions": ["sphinxcontrib.jquery"], "jquery_use_sri": True})
 
     text = out_dir.joinpath("index.html").read_text(encoding="utf-8")
+    checksum = '?v=5d32c60e' if sphinx.version_info[:2] >= (7, 1) else ''
     assert ('<script '
             'integrity="sha384-vtXRMe3mGCbOeY7l30aIg8H9p3GdeSe4IFlP6G8JMa7o7lXvnz3GFKzPxzJdPfGK" '
-            'src="_static/jquery.js"></script>') in text
+            f'src="_static/jquery.js{checksum}"></script>') in text
+    checksum = '?v=2cd50e6c' if sphinx.version_info[:2] >= (7, 1) else ''
     assert ('<script '
             'integrity="sha384-lSZeSIVKp9myfKbDQ3GkN/KHjUc+mzg17VKDN4Y2kUeBSJioB9QSM639vM9fuY//" '
-            'src="_static/_sphinx_javascript_frameworks_compat.js"></script>') in text
+            f'src="_static/_sphinx_javascript_frameworks_compat.js{checksum}"></script>') in text
 
     static_dir = out_dir / '_static'
     assert static_dir.joinpath('jquery.js').is_file()
@@ -56,10 +58,12 @@ def test_jquery_installed_sphinx_ge_60(blank_app):
     out_dir = blank_app(confoverrides={"extensions": ["sphinxcontrib.jquery"]})
 
     text = out_dir.joinpath("index.html").read_text(encoding="utf-8")
+    checksum = '?v=5d32c60e' if sphinx.version_info[:2] >= (7, 1) else ''
     assert ('<script '
-            'src="_static/jquery.js"></script>') in text
+            f'src="_static/jquery.js{checksum}"></script>') in text
+    checksum = '?v=2cd50e6c' if sphinx.version_info[:2] >= (7, 1) else ''
     assert ('<script '
-            'src="_static/_sphinx_javascript_frameworks_compat.js"></script>') in text
+            f'src="_static/_sphinx_javascript_frameworks_compat.js{checksum}"></script>') in text
 
     static_dir = out_dir / '_static'
     assert static_dir.joinpath('jquery.js').is_file()


### PR DESCRIPTION
I can't use patch from #27 in Fedora, because we already build packages with Python 3.12, and the internals of `pathlib.Path` were rewritten. See traceback below.

I tried to understand what is the desired outcome of the tests here and since Sphinx is heading towards the standard Path objects, there's no need to monkeypatch the attributes anymore: the `Path.resolve()` method does the relevant work for us.
Also, adding tests with Python 3.12 since it's already out.


```
_________________________________________ test_jquery_installed_sphinx_ge_60 __________________________________________

blank_app = <function blank_app.<locals>.inner at 0x7f2ef84f7560>

    @pytest.mark.skipif(sphinx.version_info[:2] < (6, 0),
                        reason="Requires Sphinx 6.0 or greater")
    def test_jquery_installed_sphinx_ge_60(blank_app):
>       out_dir = blank_app(confoverrides={"extensions": ["sphinxcontrib.jquery"]})

tests/test_jquery_installed.py:67: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/test_jquery_installed.py:38: in inner
    return run_blank_app(Path(tmpdir), **kwargs)
tests/test_jquery_installed.py:19: in run_blank_app
    app = SphinxTestApp(**kwargs, srcdir=srcdir)
../venv213/lib64/python3.12/site-packages/sphinx/testing/util.py:120: in __init__
    super().__init__(srcdir, confdir, outdir, doctreedir,
../venv213/lib64/python3.12/site-packages/sphinx/application.py:152: in __init__
    self.srcdir = _StrPath(srcdir).resolve()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = FakePath('/tmp/pytest-of-ksurma/pytest-4/test_jquery_installed_sphinx_g1'), args = (), kwargs = {}

    def resolve(self, *args, **kwargs):
>       return self._path
E       AttributeError: 'FakePath' object has no attribute '_path'. Did you mean: '_hash'?
```